### PR TITLE
make ParsedEnvelope public

### DIFF
--- a/src/inscriptions.rs
+++ b/src/inscriptions.rs
@@ -2,9 +2,13 @@ use super::*;
 
 use tag::Tag;
 
-pub(crate) use self::{envelope::ParsedEnvelope, media::Media};
+pub(crate) use self::media::Media;
 
-pub use self::{envelope::Envelope, inscription::Inscription, inscription_id::InscriptionId};
+pub use self::{
+  envelope::{Envelope, ParsedEnvelope},
+  inscription::Inscription,
+  inscription_id::InscriptionId,
+};
 
 mod envelope;
 mod inscription;

--- a/src/inscriptions/envelope.rs
+++ b/src/inscriptions/envelope.rs
@@ -15,7 +15,7 @@ pub(crate) const BODY_TAG: [u8; 0] = [];
 
 type Result<T> = std::result::Result<T, script::Error>;
 type RawEnvelope = Envelope<Vec<Vec<u8>>>;
-pub(crate) type ParsedEnvelope = Envelope<Inscription>;
+pub type ParsedEnvelope = Envelope<Inscription>;
 
 #[derive(Default, PartialEq, Clone, Serialize, Deserialize, Debug, Eq)]
 pub struct Envelope<T> {
@@ -90,7 +90,7 @@ impl From<RawEnvelope> for ParsedEnvelope {
 }
 
 impl ParsedEnvelope {
-  pub(crate) fn from_transaction(transaction: &Transaction) -> Vec<Self> {
+  pub fn from_transaction(transaction: &Transaction) -> Vec<Self> {
     RawEnvelope::from_transaction(transaction)
       .into_iter()
       .map(|envelope| envelope.into())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ use {
     inscriptions::{
       inscription_id,
       media::{self, ImageRendering, Media},
-      teleburn, ParsedEnvelope,
+      teleburn,
     },
     into_usize::IntoUsize,
     outgoing::Outgoing,
@@ -93,7 +93,7 @@ pub use self::{
   chain::Chain,
   fee_rate::FeeRate,
   index::{Index, RuneEntry},
-  inscriptions::{Envelope, Inscription, InscriptionId},
+  inscriptions::{Envelope, Inscription, InscriptionId, ParsedEnvelope},
   object::Object,
   options::Options,
   wallet::transaction_builder::{Target, TransactionBuilder},


### PR DESCRIPTION
We use `ParsedEnvelope` extensively in our code base, but the latest version of the upstream ord repository has made it private. So this branch is a workaround to avoid a big refactor, and should therefore be only temporary.